### PR TITLE
support decorator and context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,22 @@ for n in stop_iter(integers()):
 
 print("\ninfinity")
 ```
+Also works as a context manager:
+```python
+with stop_iter() as it:
+  for n in integers():
+    print(n)
+    if it.interrupt:
+      break
+```
+And as a decorator:
+```python
+@(it := stop_iter())
+def print_integers():
+  for n in integers():
+    print(n)
+    if it.interrupt:
+      break
+
+print_integers()
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stop-iter"
-version = "0.2.4"
+version = "0.2.5"
 description = "An interuptable iterator for Python"
 authors = ["Cristian Garcia <cgarcia.e88@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Now also works as a context manager:
```python
with stop_iter() as it:
  for n in integers():
    print(n)
    if it.interrupt:
      break
```
And as a decorator:
```python
@(it := stop_iter())
def print_integers():
  for n in integers():
    print(n)
    if it.interrupt:
      break

print_integers()
```